### PR TITLE
integrate DH3.2 logic

### DIFF
--- a/GameMod/GameMod.cs
+++ b/GameMod/GameMod.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 namespace GameMod.Core {
     public class GameMod
     {
-        public static string Version = "olmod 0.3.5";
+        public static string Version = "olmod 0.3.6 RC2 COW.5 DH3.2";
         private static Version GameVersion;
         public static bool Modded = false;
         public static bool VREnabled = false;

--- a/GameMod/MPNoPositionCompression.cs
+++ b/GameMod/MPNoPositionCompression.cs
@@ -84,7 +84,7 @@ namespace GameMod {
         /// </summary>
         /// <param name="reader"></param>
         public override void Deserialize(NetworkReader reader) {
-            float timestamp = reader.ReadSingle();
+            m_timestamp = reader.ReadSingle();
             m_num_snapshots = (int)reader.ReadByte();
             for (int i = 0; i < m_num_snapshots; i++) {
                 NetworkInstanceId net_id = reader.ReadNetworkId();
@@ -106,6 +106,7 @@ namespace GameMod {
             }
         }
 
+        public float m_timestamp;
         public int m_num_snapshots;
         public NewPlayerSnapshot[] m_snapshots = Enumerable.Range(1, 16).Select(x => new NewPlayerSnapshot()).ToArray();
 

--- a/GameMod/MPNoPositionCompression.cs
+++ b/GameMod/MPNoPositionCompression.cs
@@ -153,8 +153,7 @@ namespace GameMod {
         public static void OnNewPlayerSnapshotToClient(NetworkMessage msg) {
             if (NetworkMatch.GetMatchState() == MatchState.PREGAME || NetworkMatch.InGameplay()) {
                 NewPlayerSnapshotToClientMessage item = msg.ReadMessage<NewPlayerSnapshotToClientMessage>();
-                MPClientShipReckoning.m_last_update = item;
-                MPClientShipReckoning.m_last_update_time = NetworkMatch.m_match_elapsed_seconds;
+                MPClientShipReckoning.AddNewPlayerSnapshot(item);
             }
         }
 

--- a/GameMod/MPSetup.cs
+++ b/GameMod/MPSetup.cs
@@ -229,6 +229,7 @@ namespace GameMod {
                 Menus.mms_ship_lag_compensation_max = ModPrefs.GetInt("MP_PM_SHIP_LAG_COMPENSATION", Menus.mms_ship_lag_compensation_max);
                 Menus.mms_weapon_lag_compensation_scale = ModPrefs.GetInt("MP_PM_WEAPON_LAG_COMPENSATION_SCALE", Menus.mms_weapon_lag_compensation_scale);
                 Menus.mms_ship_lag_compensation_scale = ModPrefs.GetInt("MP_PM_SHIP_LAG_COMPENSATION_SCALE", Menus.mms_ship_lag_compensation_scale);
+                Menus.mms_ship_max_interpolate_frames = ModPrefs.GetInt("MP_PM_SHIP_MAX_INTERPOLATE_FRAMES", Menus.mms_ship_max_interpolate_frames);
             }
             else // for compatability with old olmod, no need to add new settings
             {
@@ -271,6 +272,7 @@ namespace GameMod {
             ModPrefs.SetInt("MP_PM_SHIP_LAG_COMPENSATION", Menus.mms_ship_lag_compensation_max);
             ModPrefs.SetInt("MP_PM_WEAPON_LAG_COMPENSATION_SCALE", Menus.mms_weapon_lag_compensation_scale);
             ModPrefs.SetInt("MP_PM_SHIP_LAG_COMPENSATION_SCALE", Menus.mms_ship_lag_compensation_scale);
+            ModPrefs.SetInt("MP_PM_SHIP_MAX_INTERPOLATE_FRAMES", Menus.mms_ship_max_interpolate_frames);
             ModPrefs.Flush(filename + "mod");
         }
 

--- a/GameMod/Menus.cs
+++ b/GameMod/Menus.cs
@@ -43,6 +43,7 @@ namespace GameMod
         public static int mms_ship_lag_compensation_max = 100;
         public static int mms_weapon_lag_compensation_scale = 75;
         public static int mms_ship_lag_compensation_scale = 75;
+        public static int mms_ship_max_interpolate_frames = 0;
     }
 
 
@@ -301,6 +302,8 @@ namespace GameMod
             position.y += 62f;
             SelectAndDrawSliderItem(uie, Loc.LS("SHIP LAG COMPENSATION SCALE"), position, 9, Menus.mms_ship_lag_compensation_scale, 100);
             position.y += 62f;
+            SelectAndDrawSliderItem(uie, Loc.LS("SHIP LAG MAX INTERPOLATE FRAMES"), position, 10, Menus.mms_ship_max_interpolate_frames, 3);
+            position.y += 62f;
         }
 
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
@@ -341,6 +344,9 @@ namespace GameMod
                         break;
                     case 9:
                         Menus.mms_ship_lag_compensation_scale = (int)(UIElement.SliderPos * 100f);
+                        break;
+                    case 10:
+                        Menus.mms_ship_max_interpolate_frames = (int)(UIElement.SliderPos * 3f + 0.5f);
                         break;
                     default:
                         break;


### PR DESCRIPTION
This is the DH3.2 version which improves the extapolation by using a new time sync alogirthm, and also adds back the possibility to use an interpolation scheme (which is still 50ms less lag than what vanilla overload did).